### PR TITLE
Add vnc_scroll tool for mouse-wheel scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ The MCP server provides the following tools for remote desktop control:
 **Example:** `vnc_move_mouse(x=500, y=300)`
 </details>
 
+<details>
+<summary><strong>vnc_scroll</strong> - Scroll the mouse wheel</summary>
+
+| Parameter | Required | Type | Description | Default |
+|-----------|----------|------|-------------|---------|
+| `x` | ✅ | number | X coordinate | - |
+| `y` | ✅ | number | Y coordinate | - |
+| `direction` | ❌ | string | Scroll direction (`up`, `down`, `left`, `right`) | `down` |
+| `amount` | ❌ | number | Number of wheel notches to scroll | `3` |
+
+**Example:** `vnc_scroll(x=640, y=400, direction="down", amount=5)`
+</details>
+
 ### ⌨️ Keyboard Control
 
 <details>

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,9 +12,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'));
 import { 
-  handleClick, 
-  handleMoveMouse, 
-  handleKeyPress, 
+  handleClick,
+  handleMoveMouse,
+  handleScroll,
+  handleKeyPress,
   handleTypeText, 
   handleTypeMultiline, 
   handleScreenshot 
@@ -68,6 +69,20 @@ export class VncMcpServer {
               properties: {
                 x: { type: 'number', description: 'X coordinate' },
                 y: { type: 'number', description: 'Y coordinate' }
+              },
+              required: ['x', 'y']
+            }
+          },
+          {
+            name: 'vnc_scroll',
+            description: 'Scroll the mouse wheel at the specified coordinates',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                x: { type: 'number', description: 'X coordinate' },
+                y: { type: 'number', description: 'Y coordinate' },
+                direction: { type: 'string', description: 'Scroll direction', enum: ['up', 'down', 'left', 'right'], default: 'down' },
+                amount: { type: 'number', description: 'Number of wheel notches to scroll', minimum: 1, default: 3 }
               },
               required: ['x', 'y']
             }
@@ -138,6 +153,8 @@ export class VncMcpServer {
             return await handleClick(this.vncManager, args as any);
           case 'vnc_move_mouse':
             return await handleMoveMouse(this.vncManager, args as any);
+          case 'vnc_scroll':
+            return await handleScroll(this.vncManager, args as any);
           case 'vnc_key_press':
             return await handleKeyPress(this.vncManager, args as any);
           case 'vnc_type_text':

--- a/src/test.ts
+++ b/src/test.ts
@@ -28,6 +28,7 @@ class VncMcpTester {
       await this.testScreenshot();
       await this.testMouseMovement();
       await this.testMouseClicking();
+      await this.testMouseScrolling();
       await this.testKeyboardInput();
       await this.testTextTyping();
       await this.testScreenshotDelay();
@@ -289,6 +290,38 @@ class VncMcpTester {
       const doubleClickContent = response.result.content.find((c: any) => c.type === 'text');
       if (!doubleClickContent || !doubleClickContent.text.includes('double-clicked')) {
         throw new Error('Double-click not reflected in response');
+      }
+    });
+  }
+
+  private async testMouseScrolling() {
+    await this.runTest('Mouse Scrolling', async () => {
+      // Test scroll down (default direction)
+      let response = await this.sendMcpRequest('vnc_scroll', { x: 250, y: 250 });
+      if (!response.result || !response.result.content) {
+        throw new Error('No response from scroll down');
+      }
+
+      const downContent = response.result.content.find((c: any) => c.type === 'text');
+      if (!downContent || !downContent.text.includes('Scrolled down')) {
+        throw new Error('Scroll down not reflected in response');
+      }
+
+      // Test scroll up with an explicit amount
+      response = await this.sendMcpRequest('vnc_scroll', { x: 250, y: 250, direction: 'up', amount: 5 });
+      if (!response.result || !response.result.content) {
+        throw new Error('No response from scroll up');
+      }
+
+      const upContent = response.result.content.find((c: any) => c.type === 'text');
+      if (!upContent || !upContent.text.includes('Scrolled up 5')) {
+        throw new Error('Scroll up amount not reflected in response');
+      }
+
+      // Test horizontal scrolling
+      response = await this.sendMcpRequest('vnc_scroll', { x: 250, y: 250, direction: 'right' });
+      if (!response.result || !response.result.content) {
+        throw new Error('No response from scroll right');
       }
     });
   }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,3 +1,3 @@
 // src/tools/index.ts
-export { handleClick, handleMoveMouse, handleKeyPress, handleTypeText, handleTypeMultiline } from './input.js';
+export { handleClick, handleMoveMouse, handleScroll, handleKeyPress, handleTypeText, handleTypeMultiline } from './input.js';
 export { handleScreenshot } from './screenshot.js';

--- a/src/tools/input.ts
+++ b/src/tools/input.ts
@@ -66,6 +66,50 @@ export async function handleMoveMouse(
   });
 }
 
+export async function handleScroll(
+  vncManager: VncConnectionManager,
+  args: { x: number; y: number; direction?: string; amount?: number }
+) {
+  return vncManager.executeWithConnection(async (client) => {
+    // Validate coordinates
+    const coordValidation = vncManager.validateCoordinates(client, args.x, args.y);
+    if (!coordValidation.valid) {
+      throw new Error(coordValidation.error!);
+    }
+
+    // In the RFB protocol, mouse-wheel motion is encoded as pointer button
+    // events: button 4 (up), 5 (down), 6 (left), 7 (right). Each "notch" of
+    // the wheel is a press followed by a release.
+    const wheelMap = {
+      'up': 0x08,    // button 4
+      'down': 0x10,  // button 5
+      'left': 0x20,  // button 6
+      'right': 0x40  // button 7
+    };
+
+    const direction = args.direction || 'down';
+    const buttonMask = wheelMap[direction as keyof typeof wheelMap];
+    if (buttonMask === undefined) {
+      throw new Error(`Invalid scroll direction "${direction}". Use one of: up, down, left, right`);
+    }
+
+    // Number of wheel notches to emit (default 3, matching a typical scroll step)
+    const amount = Math.max(1, Math.floor(args.amount ?? 3));
+
+    for (let i = 0; i < amount; i++) {
+      client.sendPointerEvent(args.x, args.y, buttonMask);
+      await new Promise(resolve => setTimeout(resolve, 20));
+      client.sendPointerEvent(args.x, args.y, 0);
+      await new Promise(resolve => setTimeout(resolve, 20));
+    }
+
+    const notch = amount === 1 ? 'notch' : 'notches';
+    return {
+      content: [{ type: 'text', text: `Scrolled ${direction} ${amount} ${notch} at (${args.x}, ${args.y})` }]
+    };
+  });
+}
+
 export async function handleKeyPress(
   vncManager: VncConnectionManager, 
   args: { key: string }


### PR DESCRIPTION
## Summary

Adds a dedicated `vnc_scroll` tool so agents can scroll a remote desktop directly, rather than relying on keyboard fallbacks (`Page_Down`, arrow keys, etc.).

Scrolling isn't a distinct primitive in the RFB protocol — mouse-wheel motion is encoded as pointer **button** events (buttons 4–7). This tool emits those events:

| Direction | RFB button | Mask |
|-----------|-----------|------|
| up    | 4 | `0x08` |
| down  | 5 | `0x10` |
| left  | 6 | `0x20` |
| right | 7 | `0x40` |

Each "notch" is a press + release of the wheel button at the given coordinates, which is how real VNC clients emit scroll events.

## Tool schema

`vnc_scroll`:
- `x`, `y` *(required)* — coordinates to scroll at
- `direction` *(optional)* — `up` \| `down` \| `left` \| `right` (default `down`)
- `amount` *(optional)* — number of wheel notches (default `3`)

Example: `vnc_scroll(x=640, y=400, direction="down", amount=5)`

## Changes
- `src/tools/input.ts` — new `handleScroll` handler
- `src/tools/index.ts` — export the handler
- `src/server.ts` — register `vnc_scroll` in the ListTools schema and dispatch table
- `src/test.ts` — add a `Mouse Scrolling` integration test
- `README.md` — document the tool

## Testing
- `npm run build` passes (tsc, no errors).
- Added a live integration test (`testMouseScrolling`) alongside the existing mouse tests; it exercises default scroll-down, an explicit `up`/`amount`, and horizontal scroll. Like the other tests in `src/test.ts`, it requires a reachable VNC server to run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)